### PR TITLE
Fixing Memleak

### DIFF
--- a/ratelimit.c
+++ b/ratelimit.c
@@ -115,6 +115,7 @@ int RaterLimit_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
       RedisModule_CloseKey(key);
       return RedisModule_ReplyWithError(ctx, "ERR invalid stored rater");
     }
+    RedisModule_FreeString(ctx, tat_str);
   } else if (RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_EMPTY) {
     /* If the key is not a string and is not empty it is the wrong type. */
     RedisModule_CloseKey(key);

--- a/ratelimit.c
+++ b/ratelimit.c
@@ -112,6 +112,7 @@ int RaterLimit_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
         RedisModule_CreateString(ctx, raw_tat_str, len);
 
     if (RedisModule_StringToLongLong(tat_str, &tat) != REDISMODULE_OK) {
+      RedisModule_FreeString(ctx, tat_str);
       RedisModule_CloseKey(key);
       return RedisModule_ReplyWithError(ctx, "ERR invalid stored rater");
     }


### PR DESCRIPTION
One allocated RedisModuleString object was not properly freed with corresponding RedisModule_FreeString, it caused remarkable mem leak.

This commit fix it by paring the string creating with free function call.