### PR TITLE
Allow to use a monotonic clock to prevent timing issues + more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@ uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 
 # Compile flags for linux / osx
 ifeq ($(uname_S),Linux)
-	SHOBJ_CFLAGS ?= -W -Wall -fno-common -g -ggdb -std=c99 -O2
+	SHOBJ_CFLAGS ?= -W -Wall -fno-common -g -ggdb -std=gnu99 -O2
 	SHOBJ_LDFLAGS ?= -shared
 else
-	SHOBJ_CFLAGS ?= -W -Wall -dynamic -fno-common -g -ggdb -std=c99 -O2
+	SHOBJ_CFLAGS ?= -W -Wall -dynamic -fno-common -g -ggdb -std=gnu99 -O2
 	SHOBJ_LDFLAGS ?= -bundle -undefined dynamic_lookup -macosx_version_min 10.12
+endif
+
+ifeq ($(USE_MONOTONIC_CLOCK),1)
+	SHOBJ_CFLAGS += -DUSE_MONOTONIC_CLOCK
 endif
 
 .SUFFIXES: .c .so .xo .o

--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ This is free software under the terms of MIT the license (see the file
 `LICENSE` for details).
 
 [gcra]: https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm
-[redis-modules]: https://github.com/antirez/redis/blob/unstable/src/modules/INTRO.md
+[redis-modules]: https://redis.io/topics/modules-intro

--- a/ratelimit.c
+++ b/ratelimit.c
@@ -27,6 +27,9 @@
 /* nanoseconds per second */
 #define NSEC_PER_SEC 1000000000LL
 
+/* microseconds per second */
+#define USEC_PER_SEC 1000000LL
+
 /* miliseconds per second */
 #define MSEC_PER_SEC 1000LL
 
@@ -106,7 +109,7 @@ static long long rater_limit(long long tat, long long burst,
     *remaining = next / emission_interval;
   }
 
-  *ttl = *ttl / NSEC_PER_SEC;
+  *ttl = *ttl / USEC_PER_SEC;
 
   return new_tat;
 }
@@ -184,7 +187,7 @@ int RaterLimit_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     RedisModuleString *new_tat_str =
         RedisModule_CreateStringFromLongLong(ctx, new_tat);
     RedisModule_StringSet(key, new_tat_str);
-    RedisModule_SetExpire(key, ttl * MSEC_PER_SEC);
+    RedisModule_SetExpire(key, ttl);
     RedisModule_FreeString(ctx, new_tat_str);
   }
 
@@ -200,7 +203,7 @@ int RaterLimit_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
   /* Retry after this many of seconds to get through or -1 if not limited. */
   RedisModule_ReplyWithLongLong(ctx, retry_after);
   /* Amount of seconds to wait until both the burst and the rate restarts. */
-  RedisModule_ReplyWithLongLong(ctx, ttl);
+  RedisModule_ReplyWithLongLong(ctx, ttl / MSEC_PER_SEC);
 
   return REDISMODULE_OK;
 }


### PR DESCRIPTION
This PR:
- allows users to use a monotonic clock (`make USE_MONOTONIC_CLOCK=1`). `gettimeofday()` is affected by discontinuous jumps in the system time and should not be used to measure time intervals ([here's a good explanation](https://blog.habets.se/2010/09/gettimeofday-should-never-be-used-to-measure-time.html)).
- increases the precision of the theoretical arrival times from microseconds to nanoseconds. This is in line with the other implementations [<sup>[1]</sup>](https://github.com/brandur/redis-cell/blob/64d2321f57f49e27f5ce8d3e0ea5c8c3f4ddc9a8/src/cell/mod.rs#L172) [<sup>[2]</sup>](https://github.com/throttled/throttled/blob/608de1fa042e0b10dfa8a8298467bf5dc1e66367/rate.go#L213-L217).
- solves the issue mentioned in #1 by ensuring that `rater_limit` returns the TTL in milliseconds instead of seconds.
  `X-RateLimit-Remaining` before this PR:
  ```
  [kleisauke@PC-KAW ~]$ for run in {1..6}; do redis-cli RATER.LIMIT user 5 5 1 | sed -n '3~5p'; done
  5
  5
  5
  5
  5
  5
  ```
  After:
  ```
  [kleisauke@PC-KAW ~]$ for run in {1..6}; do redis-cli RATER.LIMIT user 5 5 1 | sed -n '3~5p'; done
  5
  4
  3
  2
  1
  0
  ```

Closes #1.